### PR TITLE
Change/ update guidance on setting parent and child links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.0-beta.3] - 2026-03-05
+
 ### Added
 - **Optional Transactions Conformance Class:** Explicitly separated the management plane (`POST`, `PUT`, `DELETE`) into an optional `https://api.stacspec.org/v1.0.0-beta.2/multi-tenant-catalogs/transaction` conformance class. This ensures public-facing APIs can safely implement the core extension as read-only by default without violating the specification.
+
+### Changed
+- **STAC Browser Compatibility:** Updated Link Relations section to explicitly support poly-hierarchy with multiple `rel="parent"` links for catalogs with multiple parents. Clarified that top-level sub-catalogs without other parents MUST point to the Global Root.
+- **Dynamic Linking Specification:** Enhanced the "Safety-First Architecture" note to provide explicit implementation guidance: maintain a backend mapping of `parent_ids` and dynamically generate `rel="parent"` and `rel="child"` HATEOAS links at runtime, rather than persisting static link objects in the database.
+- **Example JSON Response:** Updated the Registry List example to demonstrate nested catalog structure with proper parent-child relationships, showing what STAC Browser and other clients should expect when traversing true Directed Acyclic Graphs (DAGs).
 
 ## [v1.0.0-beta.2] - 2026-03-02
 
@@ -28,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Updated Conformance Class URIs to match the new versioning.
 
-[Unreleased]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.2...main
+[Unreleased]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.3...main
+[v1.0.0-beta.3]:
+https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.2...v1.0.0-beta.3
 [v1.0.0-beta.2]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.1...v1.0.0-beta.2
 [v1.0.0-beta.1]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/releases/tag/v1.0.0-beta.1

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ A core tenet of this extension is **Data Safety**. It strictly separates "Organi
 * **The `/catalogs` endpoints are for Organization:** Operations here (like deleting a catalog) are **Non-Destructive**. You can disband a catalog or unlink a collection, and the extension guarantees that **no actual data (Collections or Items) is ever deleted**. If a resource is unlinked from its last parent, it is automatically adopted by the Root Catalog to prevent data loss.
 * **The `/collections` endpoints are for Data:** Actual destruction of data is reserved for the core STAC API endpoints.
 
-**Note on Dynamic Linking:**
-To ensure data consistency and reduce storage overhead, implementations SHOULD generate hierarchical links (e.g., `rel="child"`, `rel="parent"`) dynamically at runtime based on the requested endpoint context, rather than persisting static link objects in the database.
+**Note on Dynamic Linking:** To ensure data consistency, support poly-hierarchy, and accommodate flat URL routing, implementations SHOULD NOT persist static `rel="child"` or `rel="parent"` link objects in the database. 
+
+Instead, implementations SHOULD maintain a backend mapping of parent-child relationships (e.g., an array of `parent_ids` on the catalog record) and dynamically generate the `rel="parent"` and `rel="child"` HATEOAS links at runtime based on the requested endpoint.
 
 ## Endpoints
 
@@ -78,7 +79,8 @@ This extension explicitly supports **Poly-hierarchy**, allowing a single STAC Co
 Unlike a standard file system where a folder can only live in one path, this architecture allows for logical grouping across different dimensions without duplicating data.
 
 * **Example:** A `Sentinel-2` collection can be linked as a child of the `USGS` Catalog (Provider) AND the `Optical-Data` Catalog (Theme).
-* **Behavior:** When accessing a Collection via a specific Catalog endpoint (e.g., `/catalogs/{id}/collections/{col_id}`), the API SHOULD preserve the navigation context by generating a `rel="parent"` link pointing back to that specific Catalog.
+* **Contextual Navigation (Scoped Route):** When accessing a Collection via a scoped endpoint (e.g., `/catalogs/{id}/collections/{col_id}`), the API MUST generate a single `rel="parent"` link pointing exclusively back to that specific `{catalogId}`. It MUST NOT list the collection's other parents, as this would break the user's current contextual breadcrumb trail in STAC Browser.
+* **Global Discovery (Global Route):** When accessing a Collection via the global root endpoint (`/collections/{collectionId}`), the API MUST include a `rel="parent"` link for every Catalog that claims this collection as a child. If the collection is not linked to any sub-catalogs, its `rel="parent"` MUST point to the Global Root (`/`).
 
 ## Transaction Behavior
 
@@ -164,16 +166,26 @@ This is the entry point.
 - `rel="service-desc"`: Points to the OpenAPI definition.
 
 ### 2. The Sub-Catalog (`/catalogs/{catalogId}`)
-This resource acts as the **Landing Page** for the provider.
-- `rel="self"`: MUST point to `/catalogs/{catalogId}`.
-- `rel="parent"`: MUST point to the Global Root (`/`).
-- `rel="root"`: SHOULD point to the Global Root (`/`) to maintain a single navigation tree.
-- `rel="data"`: MUST point to `/catalogs/{catalogId}/collections`.
-- `rel="children"`: MUST point to `/catalogs/{catalogId}/children` (if Children extension is implemented).
+This resource acts as the Landing Page for the provider or a nested sub-folder.
+* `rel="self"`: MUST point to `/catalogs/{catalogId}`.
+* `rel="parent"`: MUST point to the immediate parent Catalog(s) that this sub-catalog is linked to. If the catalog is part of a poly-hierarchy (has multiple parents), the API MUST include a `rel="parent"` link for each. If it is a top-level sub-catalog with no other parents, it MUST point to the Global Root (`/`).
+* `rel="root"`: MUST point to the Global Root (`/`) to maintain a single navigation tree.
+* `rel="child"`: MUST point to any immediate Sub-Catalogs (`/catalogs/{subId}`) AND any linked Collections (`/catalogs/{catalogId}/collections/{collectionId}`).
+
+### 3. The Global Collection (`/collections/{collectionId}`)
+This resource represents a Collection accessible via the standard STAC core endpoint (flat, global discovery).
+* `rel="self"`: MUST point to `/collections/{collectionId}`.
+* `rel="parent"`: MUST include a `rel="parent"` link for every Catalog that claims this collection as a child. If the collection is not linked to any sub-catalogs, `rel="parent"` MUST point to the Global Root (`/`).
+* `rel="root"`: MUST point to the Global Root (`/`).
 
 ### 4. The Scoped Collection Endpoints (`/catalogs/{catalogId}/collections/{collectionId}/*`)
-This resource, and all of its sub-resources, represents a Collection within the context of a specific Catalog.
-- `rel="alternate"`: MAY be provided to point to the corresponding `/collections/{collectionId}/*` endpoints, and vice versa.
+This resource, and all of its sub-resources, represents a Collection within the context of a specific Catalog. The `rel="parent"` link is locked to the scoped path to preserve contextual breadcrumb navigation.
+* `rel="self"`: MUST point to `/catalogs/{catalogId}/collections/{collectionId}`.
+* `rel="parent"`: MUST point exclusively to `/catalogs/{catalogId}` (the specific parent through which the user navigated). It MUST NOT list other parents, even if the collection belongs to multiple catalogs.
+* `rel="alternate"`: MAY be provided to point to the corresponding `/collections/{collectionId}/*` endpoints, and vice versa.
+
+> [!NOTE]
+> **Contextual vs. Global Navigation:** The distinction between scoped and global endpoints is critical for STAC Browser and other UI clients. Scoped endpoints lock the breadcrumb trail to a single parent for clarity, while global endpoints expose the full poly-hierarchy graph. Implementations MUST respect this distinction when generating `rel="parent"` links.
 
 > [!NOTE]
 > All sub-resources can be considered, accordingly to other STAC API extensions that are implemented.
@@ -199,15 +211,16 @@ This endpoint returns a JSON object structurally similar to a standard `/collect
 {
   "catalogs": [
     {
-      "id": "usgs-landsat",
+      "id": "catalog3",
       "type": "Catalog",
-      "title": "USGS Landsat",
-      "description": "Landsat collections provided by USGS.",
+      "title": "Nested Sub-Catalog",
+      "description": "A nested catalog under catalog2.",
       "stac_version": "1.0.0",
       "links": [
-        { "rel": "self", "href": "https://api.example.com/catalogs/usgs-landsat" },
+        { "rel": "self", "href": "https://api.example.com/catalogs/catalog3" },
         { "rel": "root", "href": "https://api.example.com/" },
-        { "rel": "child", "href": "https://api.example.com/catalogs/usgs-landsat/collections" }
+        { "rel": "parent", "href": "https://api.example.com/catalogs/catalog2" },
+        { "rel": "child", "href": "https://api.example.com/catalogs/catalog3/collections" }
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Unlike a standard file system where a folder can only live in one path, this arc
 
 * **Example:** A `Sentinel-2` collection can be linked as a child of the `USGS` Catalog (Provider) AND the `Optical-Data` Catalog (Theme).
 * **Contextual Navigation (Scoped Route):** When accessing a Collection via a scoped endpoint (e.g., `/catalogs/{id}/collections/{col_id}`), the API MUST generate a single `rel="parent"` link pointing exclusively back to that specific `{catalogId}`. It MUST NOT list the collection's other parents, as this would break the user's current contextual breadcrumb trail in STAC Browser.
-* **Global Discovery (Global Route):** When accessing a Collection via the global root endpoint (`/collections/{collectionId}`), the API MUST include a `rel="parent"` link for every Catalog that claims this collection as a child. If the collection is not linked to any sub-catalogs, its `rel="parent"` MUST point to the Global Root (`/`).
+* **Global Discovery (Global Route):** When accessing a Collection via the global root endpoint (`/collections/{collectionId}`), the API MUST include a `rel="parent"` link for every Catalog that claims this collection as a child, **provided the current authenticated user has read access to those parent catalogs.**
+  * If the API implements Role-Based Access Control (RBAC), it MUST filter out links to restricted catalogs to prevent information disclosure.
+  * If the collection is not linked to any sub-catalogs, or if the user lacks access to all of its parent catalogs, the `rel="parent"` MUST fallback and point to the Global Root (`/`).
 
 ## Transaction Behavior
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ This endpoint returns a JSON object structurally similar to a standard `/collect
         { "rel": "self", "href": "https://api.example.com/catalogs/catalog3" },
         { "rel": "root", "href": "https://api.example.com/" },
         { "rel": "parent", "href": "https://api.example.com/catalogs/catalog2" },
-        { "rel": "child", "href": "https://api.example.com/catalogs/catalog3/collections" }
+        { "rel": "data", "href": "https://api.example.com/catalogs/catalog3/collections" }
       ]
     },
     {
@@ -232,7 +232,7 @@ This endpoint returns a JSON object structurally similar to a standard `/collect
       "links": [
         { "rel": "self", "href": "https://api.example.com/catalogs/esa-sentinel" },
         { "rel": "root", "href": "https://api.example.com/" },
-        { "rel": "child", "href": "https://api.example.com/catalogs/esa-sentinel/collections" }
+        { "rel": "data", "href": "https://api.example.com/catalogs/esa-sentinel/collections" }
       ]
     }
   ],

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: STAC API Multi-Tenant Catalogs Endpoint Extension
-  version: 1.0.0-beta.2
+  version: 1.0.0-beta.3
   description: |
     An extension that adds a dedicated `/catalogs` endpoint to support a 
     Multi-Tenant architecture. It allows a STAC API to act as a registry for 
@@ -62,6 +62,12 @@ paths:
       tags:
         - "Discovery (Core)"
       summary: Get the Landing Page for a specific sub-catalog
+      description: |
+        Returns a STAC Catalog/Landing Page. 
+        **Note on Links:** To support poly-hierarchy and UI traversal (e.g., STAC Browser), 
+        the `links` array is dynamically generated. It MUST include a `rel="child"` link 
+        for each nested sub-catalog/collection, and MAY include multiple `rel="parent"` links 
+        if the catalog is linked to multiple parent catalogs.
       operationId: getCatalog
       responses:
         '200':
@@ -130,7 +136,9 @@ paths:
       summary: Create or Link a Sub-Catalog
       description: |
         Creates a new catalog and links it as a child of {catalogId}, OR links 
-        an existing catalog by passing its ID (Link by Reference).
+        an existing catalog by passing its ID (Link by Reference). 
+        Linking by reference allows for Poly-Hierarchy (Directed Acyclic Graphs), 
+        where a single catalog can have multiple parents.
       operationId: createSubCatalog
       requestBody:
         required: true
@@ -230,7 +238,9 @@ paths:
       summary: Create or Link a Collection in this Catalog
       description: |
         Creates a new collection and links it as a child of {catalogId}, OR links 
-        an existing collection by passing its ID (Link by Reference).
+        an existing collection by passing its ID (Link by Reference). 
+        Linking by reference allows for Poly-Hierarchy (Directed Acyclic Graphs), 
+        where a single collection can belong to multiple catalogs.
       operationId: createCatalogCollection
       requestBody:
         required: true


### PR DESCRIPTION
## Objective
This PR updates the extension specification to fully embrace **Directed Acyclic Graphs (DAGs)** for catalog organization. It removes the previous constraint that forced all sub-catalogs to point their `rel="parent"` links back to the global root (`/`), replacing it with a true contextual poly-hierarchy model. 

These updates ensure that nested folder structures render in UI clients like **STAC Browser** while remaining strictly compliant with core STAC HATEOAS principles.

## Key Changes
* **Updated `rel="parent"` Logic (`README.md`):** Sub-catalogs must now point their parent links to their *actual* immediate parent(s). If a catalog is linked to multiple parents (poly-hierarchy), the API must return multiple `rel="parent"` links.
* **Explicit `rel="child"` Requirement:** Added explicit instructions that APIs must dynamically generate `rel="child"` links for downward hierarchy traversal.
* **Clarified Dynamic Linking:** Updated the "Safety-First Architecture" note to better explain how backends should use `parent_ids` arrays to generate these links at runtime rather than persisting them statically.
* **Updated JSON Examples:** Replaced the flat registry examples with nested catalog examples (e.g., `catalog3` linked under `catalog2`) to give frontend developers a clear picture of deep tree HATEOAS navigation.
* **Updated `openapi.yaml`:** * Bumped version to reflect these structural updates.
  * Added descriptive warnings to the `GET /catalogs/{catalogId}` and `POST` routes explaining the dynamic generation of links and the DAG/poly-hierarchy behavior.

## Why this matters
Previously, because the API routes for sub-catalogs are flat (e.g., `GET /catalogs/{id}`), the spec assumed the structural parent had to be the root. However, this broke STAC Browser's ability to draw "Up" buttons and breadcrumb trails for deep organizational trees. By allowing the API to return the true graph state via multiple `rel="parent"` and `rel="child"` links, we enable rich, multi-dimensional folder navigation without duplicating any data.