### PR TITLE
Refactor: Enforce strict single `rel="parent"` linking and support poly-hierarchy via `rel="related"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Poly-Hierarchy via `rel="related"`**: Implemented `rel="related"` links to expose alternative parents for collections and catalogs belonging to multiple catalogs simultaneously, preserving Directed Acyclic Graph (DAG) traversal for advanced clients.
 
 ### Changed
-- **Strict Single `rel="parent"` Linking**: Updated dynamic link generation across all endpoints to strictly enforce a single, contextual `rel="parent"` link based on the request route. This ensures 100% backward compatibility with naive UI clients (like STAC Browser) and protects breadcrumb navigation.
+- **Strict Single `rel="parent"` Linking**: Updated dynamic link generation across all endpoints to strictly enforce a single, contextual `rel="parent"` link based on the request route. This helps ensure backward compatibility with naive UI clients (like STAC Browser) and protects breadcrumb navigation.
 - **Documentation & OpenAPI**: Updated the extension specification and OpenAPI definitions to formally document the "One Parent, Multiple Related" poly-hierarchy consensus.
 
 ## [v1.0.0-beta.3] - 2026-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Poly-Hierarchy via `rel="related"`**: Implemented `rel="related"` links to expose alternative parents for collections and catalogs belonging to multiple catalogs simultaneously, preserving Directed Acyclic Graph (DAG) traversal for advanced clients.
 
 ### Changed
-- **Strict Single `rel="parent"` Linking**: Updated dynamic link generation across all endpoints to strictly enforce a single, contextual `rel="parent"` link based on the request route. This helps ensure backward compatibility with naive UI clients (like STAC Browser) and protects breadcrumb navigation.
+- **Strict Single `rel="parent"` Linking**: Updated dynamic link generation across all endpoints to strictly enforce a single, contextual `rel="parent"` link based on the request route. This helps ensure backward compatibility with UI clients (like STAC Browser) and protects breadcrumb navigation.
 - **Documentation & OpenAPI**: Updated the extension specification and OpenAPI definitions to formally document the "One Parent, Multiple Related" poly-hierarchy consensus.
 
 ## [v1.0.0-beta.3] - 2026-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Poly-Hierarchy via `rel="related"`**: Implemented `rel="related"` links to expose alternative parents for collections and catalogs belonging to multiple catalogs simultaneously, preserving Directed Acyclic Graph (DAG) traversal for advanced clients.
+
+### Changed
+- **Strict Single `rel="parent"` Linking**: Updated dynamic link generation across all endpoints to strictly enforce a single, contextual `rel="parent"` link based on the request route. This ensures 100% backward compatibility with naive UI clients (like STAC Browser) and protects breadcrumb navigation.
+- **Documentation & OpenAPI**: Updated the extension specification and OpenAPI definitions to formally document the "One Parent, Multiple Related" poly-hierarchy consensus.
+
 ## [v1.0.0-beta.3] - 2026-03-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A core tenet of this extension is **Data Safety**. It strictly separates "Organi
 
 **Note on Dynamic Linking:** To ensure data consistency, support poly-hierarchy, and accommodate flat URL routing, implementations SHOULD NOT persist static `rel="child"` or `rel="parent"` link objects in the database. 
 
-Instead, implementations SHOULD maintain a backend mapping of parent-child relationships (e.g., an array of `parent_ids` on the catalog record) and dynamically generate the `rel="parent"` and `rel="child"` HATEOAS links at runtime based on the requested endpoint.
+Instead, implementations SHOULD maintain a backend mapping of parent-child relationships (e.g., an array of `parent_ids` on the catalog record) and dynamically generate the `rel="parent"`, `rel="child"`, and `rel="related"` HATEOAS links at runtime based on the requested endpoint.
 
 ## Endpoints
 
@@ -74,15 +74,14 @@ These endpoints allow for the dynamic creation and deletion of the federation st
 
 ## Poly-Hierarchy (Multi-Parenting)
 
-This extension explicitly supports **Poly-hierarchy**, allowing a single STAC Collection to belong to **multiple Catalogs simultaneously**.
+This extension explicitly supports **Poly-hierarchy**, allowing a single STAC Collection or Catalog to belong to **multiple Catalogs simultaneously**.
 
-Unlike a standard file system where a folder can only live in one path, this architecture allows for logical grouping across different dimensions without duplicating data.
+Unlike a standard file system where a folder can only live in one path, this architecture allows for logical grouping across different dimensions without duplicating data. 
 
 * **Example:** A `Sentinel-2` collection can be linked as a child of the `USGS` Catalog (Provider) AND the `Optical-Data` Catalog (Theme).
-* **Contextual Navigation (Scoped Route):** When accessing a Collection via a scoped endpoint (e.g., `/catalogs/{id}/collections/{col_id}`), the API MUST generate a single `rel="parent"` link pointing exclusively back to that specific `{catalogId}`. It MUST NOT list the collection's other parents, as this would break the user's current contextual breadcrumb trail in STAC Browser.
-* **Global Discovery (Global Route):** When accessing a Collection via the global root endpoint (`/collections/{collectionId}`), the API MUST include a `rel="parent"` link for every Catalog that claims this collection as a child, **provided the current authenticated user has read access to those parent catalogs.**
+* **Contextual Navigation (Scoped Route):** When accessing a Collection via a scoped endpoint (e.g., `/catalogs/{id}/collections/{col_id}`), the API MUST generate exactly one `rel="parent"` link pointing exclusively back to that specific `{catalogId}` to preserve the user's current contextual breadcrumb trail in UI clients. Alternative parents in the poly-hierarchy MUST be exposed as `rel="related"` links.
+* **Global Discovery (Global Route):** When accessing a Collection via the global root endpoint (`/collections/{collectionId}`), the API MUST generate exactly one `rel="parent"` link pointing to the Global Root (`/`). To expose the poly-hierarchy, the API MUST include a `rel="related"` link for every Catalog that claims this collection as a child, provided the current authenticated user has read access to those parent catalogs.
   * If the API implements Role-Based Access Control (RBAC), it MUST filter out links to restricted catalogs to prevent information disclosure.
-  * If the collection is not linked to any sub-catalogs, or if the user lacks access to all of its parent catalogs, the `rel="parent"` MUST fallback and point to the Global Root (`/`).
 
 ## Transaction Behavior
 
@@ -110,7 +109,7 @@ This endpoint supports two distinct modes of operation: **Creation** and **Linki
 * **Body:** A JSON object containing only the `id`. Example: `{"id": "existing-catalog-id"}`.
 * **Condition:** The `id` already exists in the database.
 * **Behavior:**
-    1.  **Establishes Reciprocal Links:** Adds `{catalogId}` to the sub-catalog's parent list, AND adds a `rel="child"` link to the parent Catalog pointing to the sub-catalog.
+    1.  **Establishes Reciprocal Links:** Adds `{catalogId}` to the sub-catalog's internal parent list (which dynamically resolves to `rel="parent"` or `rel="related"` links at read-time).
     2.  Returns `200 OK` to indicate a successful link.
     3.  **Error Handling:** If the `id` does not exist when using this minimal payload, the API MUST return `404 Not Found`.
     4.  **Cycle Prevention:** Implementations SHOULD reject links that create a circular reference (e.g., linking a parent as a child of itself).
@@ -170,24 +169,27 @@ This is the entry point.
 ### 2. The Sub-Catalog (`/catalogs/{catalogId}`)
 This resource acts as the Landing Page for the provider or a nested sub-folder.
 * `rel="self"`: MUST point to `/catalogs/{catalogId}`.
-* `rel="parent"`: MUST point to the immediate parent Catalog(s) that this sub-catalog is linked to. If the catalog is part of a poly-hierarchy (has multiple parents), the API MUST include a `rel="parent"` link for each. If it is a top-level sub-catalog with no other parents, it MUST point to the Global Root (`/`).
+* `rel="parent"`: MUST point to **exactly one** immediate parent Catalog that this sub-catalog was accessed through. If it is a top-level sub-catalog, it MUST point to the Global Root (`/`).
+* `rel="related"`: If the catalog is part of a poly-hierarchy (has multiple parents), the API MUST include this link for all *other* parent catalogs to expose the broader graph.
 * `rel="root"`: MUST point to the Global Root (`/`) to maintain a single navigation tree.
 * `rel="child"`: MUST point to any immediate Sub-Catalogs (`/catalogs/{subId}`) AND any linked Collections (`/catalogs/{catalogId}/collections/{collectionId}`).
 
 ### 3. The Global Collection (`/collections/{collectionId}`)
 This resource represents a Collection accessible via the standard STAC core endpoint (flat, global discovery).
 * `rel="self"`: MUST point to `/collections/{collectionId}`.
-* `rel="parent"`: MUST include a `rel="parent"` link for every Catalog that claims this collection as a child. If the collection is not linked to any sub-catalogs, `rel="parent"` MUST point to the Global Root (`/`).
+* `rel="parent"`: MUST point to **exactly one** parent, which is the Global Root (`/`).
+* `rel="related"`: MUST include a link for every Sub-Catalog that claims this collection as a child, exposing the poly-hierarchy.
 * `rel="root"`: MUST point to the Global Root (`/`).
 
 ### 4. The Scoped Collection Endpoints (`/catalogs/{catalogId}/collections/{collectionId}/*`)
 This resource, and all of its sub-resources, represents a Collection within the context of a specific Catalog. The `rel="parent"` link is locked to the scoped path to preserve contextual breadcrumb navigation.
 * `rel="self"`: MUST point to `/catalogs/{catalogId}/collections/{collectionId}`.
-* `rel="parent"`: MUST point exclusively to `/catalogs/{catalogId}` (the specific parent through which the user navigated). It MUST NOT list other parents, even if the collection belongs to multiple catalogs.
+* `rel="parent"`: MUST point **exclusively** to `/catalogs/{catalogId}` (the specific parent through which the user navigated). It MUST NOT list other parents as `rel="parent"`, as this breaks UI breadcrumbs.
+* `rel="related"`: MAY be included to expose the collection's alternative parents in the poly-hierarchy.
 * `rel="alternate"`: MAY be provided to point to the corresponding `/collections/{collectionId}/*` endpoints, and vice versa.
 
 > [!NOTE]
-> **Contextual vs. Global Navigation:** The distinction between scoped and global endpoints is critical for STAC Browser and other UI clients. Scoped endpoints lock the breadcrumb trail to a single parent for clarity, while global endpoints expose the full poly-hierarchy graph. Implementations MUST respect this distinction when generating `rel="parent"` links.
+> **Contextual vs. Global Navigation:** The distinction between scoped and global endpoints is critical for STAC Browser and other UI clients. Scoped endpoints lock the breadcrumb trail to a single parent for clarity, while global endpoints expose the full poly-hierarchy graph. Implementations MUST respect this distinction when generating `rel="parent"` and `rel="related"` links.
 
 > [!NOTE]
 > All sub-resources can be considered, accordingly to other STAC API extensions that are implemented.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Unlike a standard file system where a folder can only live in one path, this arc
 
 * **Example:** A `Sentinel-2` collection can be linked as a child of the `USGS` Catalog (Provider) AND the `Optical-Data` Catalog (Theme).
 * **Contextual Navigation (Scoped Route):** When accessing a Collection via a scoped endpoint (e.g., `/catalogs/{id}/collections/{col_id}`), the API MUST generate exactly one `rel="parent"` link pointing exclusively back to that specific `{catalogId}` to preserve the user's current contextual breadcrumb trail in UI clients. Alternative parents in the poly-hierarchy MUST be exposed as `rel="related"` links.
-* **Global Discovery (Global Route):** When accessing a Collection via the global root endpoint (`/collections/{collectionId}`), the API MUST generate exactly one `rel="parent"` link pointing to the Global Root (`/`). To expose the poly-hierarchy, the API MUST include a `rel="related"` link for every Catalog that claims this collection as a child, provided the current authenticated user has read access to those parent catalogs.
+* **Global Discovery (Global Route):** When accessing a Collection via the global root endpoint (`/collections/{collectionId}`), the API MUST generate exactly one `rel="parent"` link pointing to the Global Root (`/`). To expose the poly-hierarchy, the API MAY include a `rel="related"` link for every Catalog that claims this collection as a child, provided the current authenticated user has read access to those parent catalogs.
   * If the API implements Role-Based Access Control (RBAC), it MUST filter out links to restricted catalogs to prevent information disclosure.
 
 ## Transaction Behavior

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -66,8 +66,9 @@ paths:
         Returns a STAC Catalog/Landing Page. 
         **Note on Links:** To support poly-hierarchy and UI traversal (e.g., STAC Browser), 
         the `links` array is dynamically generated. It MUST include a `rel="child"` link 
-        for each nested sub-catalog/collection, and MAY include multiple `rel="parent"` links 
-        if the catalog is linked to multiple parent catalogs.
+        for each nested sub-catalog/collection. It MUST include exactly one `rel="parent"` link 
+        pointing to the context through which it was accessed. Alternative parents in a 
+        poly-hierarchy MUST be represented using `rel="related"` links.
       operationId: getCatalog
       responses:
         '200':


### PR DESCRIPTION
Issues: #10 

**Title:** Refactor: Enforce strict single `rel="parent"` linking and support poly-hierarchy via `rel="related"`

**Summary**
This PR updates the dynamic link generation for the Multi-Tenant Catalogs extension to align with community consensus regarding UI compatibility and Directed Acyclic Graph (DAG) traversal. It resolves issues with breadcrumb navigation in legacy clients (like STAC Browser) by enforcing a strict single structural parent, while preserving poly-hierarchy (multi-parenting) via `rel="related"` links.

**Key Changes**
* **Strict Single `rel="parent"` Linking:** Updated link generation across all endpoints to ensure a single, contextual `rel="parent"` is returned based on the specific request route. This protects breadcrumb navigation and guarantees backward compatibility with naive UI clients. 
* **Poly-Hierarchy via `rel="related"`:** Implemented `rel="related"` links to expose alternative parents. When a Collection or Catalog belongs to multiple catalogs simultaneously, advanced clients can still traverse the full DAG without breaking the single-parent core STAC constraint.
* **Documentation & OpenAPI:** Fully updated the extension specification and OpenAPI definitions to formally document the "One Parent, Multiple Related" consensus.