### PR TITLE
Add PUT scoped collection route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v1.0.0-beta.5] - 2026-05-20
+## [v1.0.0-rc.1] - 2026-05-20
 
 ### Added
 - **Scoped Collection Update (`PUT`)**: Added `PUT /catalogs/{catalogId}/collections/{collectionId}` endpoint to update collection metadata within a scoped catalog context. This operation preserves existing hierarchy links (parent_ids) unless explicitly modified.
@@ -53,8 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Updated Conformance Class URIs to match the new versioning.
 
-[Unreleased]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.5...main
-[v1.0.0-beta.5]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.4...v1.0.0-beta.5
+[Unreleased]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-rc.1...main
+[v1.0.0-rc.1]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.4...v1.0.0-rc.1
 [v1.0.0-beta.4]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.3...v1.0.0-beta.4
 [v1.0.0-beta.3]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.2...v1.0.0-beta.3
 [v1.0.0-beta.2]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.1...v1.0.0-beta.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.0-beta.5] - 2026-05-20
+
+### Added
+- **Scoped Collection Update (`PUT`)**: Added `PUT /catalogs/{catalogId}/collections/{collectionId}` endpoint to update collection metadata within a scoped catalog context. This operation preserves existing hierarchy links (parent_ids) unless explicitly modified.
+- **DAG Preservation Guidance**: Added documentation note recommending that updates to collections be performed through scoped routes rather than core STAC routes to properly preserve the poly-hierarchy DAG structure.
+
 ## [v1.0.0-beta.4] - 2026-03-13
 
 ### Added
@@ -47,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Updated Conformance Class URIs to match the new versioning.
 
-[Unreleased]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.4...main
+[Unreleased]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.5...main
+[v1.0.0-beta.5]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.4...v1.0.0-beta.5
 [v1.0.0-beta.4]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.3...v1.0.0-beta.4
 [v1.0.0-beta.3]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.2...v1.0.0-beta.3
 [v1.0.0-beta.2]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.1...v1.0.0-beta.2

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ These endpoints allow for the dynamic creation and deletion of the federation st
 | `POST` | `/catalogs/{catalogId}/catalogs` | **Link or Create Sub-Catalog.** Links an existing catalog OR creates a new one. |
 | `DELETE` | `/catalogs/{catalogId}/catalogs/{subCatalogId}` | **Unlink Sub-Catalog.** Removes the link to the sub-catalog. **Safety: Does not delete the sub-catalog.** |
 | `POST` | `/catalogs/{catalogId}/collections` | **Link or Create Collection.** Links an existing collection OR creates a new one. |
+| `PUT`  | `/catalogs/{catalogId}/collections/{collectionId}` | **Update Collection.** Updates metadata (Title, Description). **Safety: Preserves existing hierarchy links.** |
 | `DELETE` | `/catalogs/{catalogId}/collections/{collectionId}` | **Unlink Collection.** Removes the link from the parent catalog. **Safety: Never deletes the collection data.** |
 
 ## Poly-Hierarchy (Multi-Parenting)
@@ -95,6 +96,14 @@ Implementations supporting the Transaction endpoints MUST adhere to the followin
 * **Body:** Accepts a standard STAC Catalog JSON object.
 * **Behavior:** Updates the metadata (Title, Description, etc.) of the catalog.
 * **Safety:** This operation MUST NOT modify the structural links (`parent_ids`) of the catalog unless explicitly handled, ensuring the catalog remains in its current hierarchy.
+
+### 2.1. Scoped Collection Update (`PUT /catalogs/{catalogId}/collections/{collectionId}`)
+* **Body:** Accepts a standard STAC Collection JSON object.
+* **Behavior:** Updates the metadata (Title, Description, etc.) of the collection within the scoped catalog context.
+* **Safety:** This operation MUST NOT modify the structural links (`parent_ids`) of the collection unless explicitly handled, ensuring the collection remains in its current hierarchy.
+
+> [!NOTE]
+> To preserve the poly-hierarchy DAG structure, updates to collections SHOULD be performed through scoped routes (`/catalogs/{catalogId}/collections/{collectionId}`) rather than the core STAC route (`/collections/{collectionId}`). The core route is flat and does not maintain parent-child relationships, so updates through that route may not properly preserve the hierarchical context.
 
 ### 3. Sub-Catalog Creation (`POST /catalogs/{id}/catalogs`)
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -288,6 +288,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Collection'
+    put:
+      tags:
+        - "Management (Optional Transactions)"
+      summary: Update Collection Metadata
+      description: |
+        Updates the collection's title, description, and other metadata.
+        This operation preserves existing hierarchy links (parent_ids) 
+        unless explicitly modified.
+      operationId: updateCatalogCollection
+      requestBody:
+        description: The updated Collection definition
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Collection'
+      responses:
+        '200':
+          description: Collection updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
     delete:
       tags:
         - "Management (Optional Transactions)"


### PR DESCRIPTION
https://github.com/stac-utils/stac-fastapi-pgstac/pull/366

- **Scoped Collection Update (`PUT`)**: Added `PUT /catalogs/{catalogId}/collections/{collectionId}` endpoint to update collection metadata within a scoped catalog context. This operation preserves existing hierarchy links (parent_ids) unless explicitly modified.
- **DAG Preservation Guidance**: Added documentation note recommending that updates to collections be performed through scoped routes rather than core STAC routes to properly preserve the poly-hierarchy DAG structure.
- **Release** v1.0.0.rc.1