### PR TITLE
Add catalogs search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.0-rc.2] - 2026-06-15
+
+### Added
+- **Scoped Search Endpoints:** Introduced `GET /catalogs/{catalogId}/search` and `POST /catalogs/{catalogId}/search` to allow STAC item searches strictly bounded to a catalog's descendant tree. Included a new optional `https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs/search` conformance class for APIs to explicitly advertise this capability.
+
+### Changed
+- **Release Candidate 2:** Bumped the extension version and updated all associated conformance class URIs from `v1.0.0-beta.4` to `v1.0.0-rc.2` to reflect the progression toward a stable release.
+
 ## [v1.0.0-rc.1] - 2026-05-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Updated Conformance Class URIs to match the new versioning.
 
-[Unreleased]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-rc.1...main
+[Unreleased]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-rc.2...main
+[v1.0.0-rc.2]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-rc.1...v1.0.0-rc.2
 [v1.0.0-rc.1]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.4...v1.0.0-rc.1
 [v1.0.0-beta.4]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.3...v1.0.0-beta.4
 [v1.0.0-beta.3]: https://github.com/Healy-Hyperspatial/multi-tenant-catalogs/compare/v1.0.0-beta.2...v1.0.0-beta.3

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 - **Conformance Classes:**
   - `https://api.stacspec.org/v1.0.0/core` (required)
   - `https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs` (required)
+  - `https://api.stacspec.org/v1.0.0/item-search` (required IF implementing scoped search)
   - `https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs/search` (optional)
   - `https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs/transaction` (optional)
   - `https://api.stacspec.org/v1.0.0-rc.2/children` (recommended)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Instead, implementations SHOULD maintain a backend mapping of parent-child relat
 | `GET` | `/catalogs/{catalogId}/conformance` | Conformance classes specific to this sub-catalog. |
 | `GET` | `/catalogs/{catalogId}/queryables` | Filter Extension. Lists fields available for filtering in this sub-catalog. |
 | `GET` | `/catalogs/{catalogId}/search` | **Scoped Search.** Performs a STAC search strictly bounded to this catalog's descendant tree. |
-| `POST`| `/catalogs/{catalogId}/search` | **Scoped Search.** Performs a STAC search strictly bounded to this catalog's descendant tree. |
+| `POST` | `/catalogs/{catalogId}/search` | **Scoped Search.** Performs a STAC search strictly bounded to this catalog's descendant tree. |
 | `GET` | `/catalogs/{catalogId}/children` | **Children.** Lists all child resources (Catalogs and Collections). Supports filtering via `?type=Catalog` or `?type=Collection`. |
 | `GET` | `/catalogs/{catalogId}/catalogs` | **Sub-Catalogs List.** Lists only the child catalogs of this catalog (for hierarchy traversal). |
 | `GET` | `/catalogs/{catalogId}/collections` | Lists collections belonging to this sub-catalog. |

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 - **Title:** Multi-Tenant Catalogs Endpoint
 - **Conformance Classes:**
   - `https://api.stacspec.org/v1.0.0/core` (required)
-  - `https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs` (required)
-  - `https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs/transaction` (optional)
+  - `https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs` (required)
+  - `https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs/search` (optional)
+  - `https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs/transaction` (optional)
   - `https://api.stacspec.org/v1.0.0-rc.2/children` (recommended)
 - **Scope:** STAC API - Core
 - **Extension Maturity Classification:** Proposal
@@ -12,7 +13,8 @@
   - [STAC API - Core](https://github.com/radiantearth/stac-api-spec/blob/main/core)
   - [STAC API - Collections](https://github.com/radiantearth/stac-api-spec/tree/main/ogcapi-features)
   - [STAC API - Children](https://github.com/stac-api-extensions/children)
-  - [STAC API - Transaction](https://github.com/radiantearth/stac-api-spAec/tree/main/ogcapi-features/extensions/transaction) (Reference pattern)
+  - [STAC API - Item Search](https://github.com/radiantearth/stac-api-spec/tree/main/item-search) (Required if implementing scoped search)
+  - [STAC API - Transaction](https://github.com/radiantearth/stac-api-spec/tree/main/ogcapi-features/extensions/transaction) (Reference pattern)
 - **Owner**: @jonhealy1
 
 ## Introduction
@@ -51,6 +53,8 @@ Instead, implementations SHOULD maintain a backend mapping of parent-child relat
 | `GET` | `/catalogs/{catalogId}` | **Sub-Catalog Root.** Acts as the Landing Page for the provider. |
 | `GET` | `/catalogs/{catalogId}/conformance` | Conformance classes specific to this sub-catalog. |
 | `GET` | `/catalogs/{catalogId}/queryables` | Filter Extension. Lists fields available for filtering in this sub-catalog. |
+| `GET` | `/catalogs/{catalogId}/search` | **Scoped Search.** Performs a STAC search strictly bounded to this catalog's descendant tree. |
+| `POST`| `/catalogs/{catalogId}/search` | **Scoped Search.** Performs a STAC search strictly bounded to this catalog's descendant tree. |
 | `GET` | `/catalogs/{catalogId}/children` | **Children.** Lists all child resources (Catalogs and Collections). Supports filtering via `?type=Catalog` or `?type=Collection`. |
 | `GET` | `/catalogs/{catalogId}/catalogs` | **Sub-Catalogs List.** Lists only the child catalogs of this catalog (for hierarchy traversal). |
 | `GET` | `/catalogs/{catalogId}/collections` | Lists collections belonging to this sub-catalog. |
@@ -72,6 +76,20 @@ These endpoints allow for the dynamic creation and deletion of the federation st
 | `POST` | `/catalogs/{catalogId}/collections` | **Link or Create Collection.** Links an existing collection OR creates a new one. |
 | `PUT`  | `/catalogs/{catalogId}/collections/{collectionId}` | **Update Collection.** Updates metadata (Title, Description). **Safety: Preserves existing hierarchy links.** |
 | `DELETE` | `/catalogs/{catalogId}/collections/{collectionId}` | **Unlink Collection.** Removes the link from the parent catalog. **Safety: Never deletes the collection data.** |
+
+## Scoped Search (Recursive Traversal)
+
+If an implementation supports the `Item Search` conformance class, it MAY expose the scoped search endpoints (`GET /catalogs/{catalogId}/search` and `POST /catalogs/{catalogId}/search`). 
+
+If an implementation exposes these endpoints, it **MUST** advertise the `https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs/search` conformance class.
+
+These endpoints MUST accept the exact same query parameters and JSON payloads as the core STAC `/search` endpoint, but their evaluation scope is strictly bound to the hierarchy of `{catalogId}`.
+
+To properly support the recursive nature of the Multi-Tenant Catalogs extension, the scoped search **MUST** evaluate items from:
+1. All Collections directly linked as children of `{catalogId}`.
+2. All Collections linked to **any descendant Sub-Catalog** nested beneath `{catalogId}`.
+
+**Security & Intersections:** The API MUST ensure that users cannot escape the catalog boundary. If a user provides a `collections` array in their search payload, the API MUST compute the intersection of the user's requested collections and the catalog's allowed descendant collections. Any requested collections outside of the descendant tree MUST be ignored or result in an authorization error.
 
 ## Poly-Hierarchy (Multi-Parenting)
 
@@ -182,6 +200,7 @@ This resource acts as the Landing Page for the provider or a nested sub-folder.
 * `rel="related"`: If the catalog is part of a poly-hierarchy (has multiple parents), the API MAY include this link for all *other* parent catalogs to expose the broader graph.
 * `rel="root"`: MUST point to the Global Root (`/`) to maintain a single navigation tree.
 * `rel="child"`: MUST point to any immediate Sub-Catalogs (`/catalogs/{subId}`) AND any linked Collections (`/catalogs/{catalogId}/collections/{collectionId}`).
+* `rel="search"`: MAY point to `/catalogs/{catalogId}/search` if the API implements the scoped search functionality.
 
 ### 3. The Global Collection (`/collections/{collectionId}`)
 This resource represents a Collection accessible via the standard STAC core endpoint (flat, global discovery).
@@ -232,7 +251,8 @@ This endpoint returns a JSON object structurally similar to a standard `/collect
         { "rel": "self", "href": "https://api.example.com/catalogs/catalog3" },
         { "rel": "root", "href": "https://api.example.com/" },
         { "rel": "parent", "href": "https://api.example.com/catalogs/catalog2" },
-        { "rel": "data", "href": "https://api.example.com/catalogs/catalog3/collections" }
+        { "rel": "data", "href": "https://api.example.com/catalogs/catalog3/collections" },
+        { "rel": "search", "href": "https://api.example.com/catalogs/catalog3/search", "type": "application/geo+json" }
       ]
     },
     {
@@ -244,7 +264,8 @@ This endpoint returns a JSON object structurally similar to a standard `/collect
       "links": [
         { "rel": "self", "href": "https://api.example.com/catalogs/esa-sentinel" },
         { "rel": "root", "href": "https://api.example.com/" },
-        { "rel": "data", "href": "https://api.example.com/catalogs/esa-sentinel/collections" }
+        { "rel": "data", "href": "https://api.example.com/catalogs/esa-sentinel/collections" },
+        { "rel": "search", "href": "https://api.example.com/catalogs/esa-sentinel/search", "type": "application/geo+json" }
       ]
     }
   ],
@@ -274,8 +295,9 @@ The global root remains a standard STAC Landing Page. Note the addition of the `
   "description": "A standard STAC API that also supports multi-tenant catalogs.",
   "conformsTo": [
     "https://api.stacspec.org/v1.0.0/core",
-    "https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs",
-    "https://api.stacspec.org/v1.0.0-beta.4/multi-tenant-catalogs/transaction"
+    "https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs",
+    "https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs/search",
+    "https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs/transaction"
   ],
   "links": [
     {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,6 +11,7 @@ info:
     **Conformance Classes:**
     * Core (Read-Only): `.../multi-tenant-catalogs`
     * Search (Optional): `.../multi-tenant-catalogs/search`
+    * Item Search Base: `https://api.stacspec.org/v1.0.0/item-search` (Required if Search is implemented)
     * Management (Optional): `.../multi-tenant-catalogs/transaction`
     
     Includes "Safety-First" transaction logic where deletions via this endpoint 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: STAC API Multi-Tenant Catalogs Endpoint Extension
-  version: 1.0.0-beta.4
+  version: 1.0.0-rc.2
   description: |
     An extension that adds a dedicated `/catalogs` endpoint to support a 
     Multi-Tenant architecture. It allows a STAC API to act as a registry for 
@@ -10,6 +10,7 @@ info:
     
     **Conformance Classes:**
     * Core (Read-Only): `.../multi-tenant-catalogs`
+    * Search (Optional): `.../multi-tenant-catalogs/search`
     * Management (Optional): `.../multi-tenant-catalogs/transaction`
     
     Includes "Safety-First" transaction logic where deletions via this endpoint 
@@ -216,7 +217,96 @@ paths:
                 type: object
 
   # ----------------------------------------------------------------------
-  # 6. SCOPED COLLECTIONS MANAGEMENT
+  # 6. SCOPED SEARCH (Optional)
+  # ----------------------------------------------------------------------
+  /catalogs/{catalogId}/search:
+    parameters:
+      - $ref: '#/components/parameters/catalogId'
+    get:
+      tags:
+        - "Discovery (Core)"
+      summary: Search items in a catalog's descendant tree
+      description: |
+        Performs a STAC item search strictly bounded to the hierarchy of {catalogId}.
+        Evaluates items from all Collections directly linked to {catalogId} and 
+        all Collections linked to any descendant Sub-Catalog nested beneath {catalogId}.
+        
+        Accepts the same query parameters as the core STAC `/search` endpoint. 
+        The `collections` parameter is intersected with the catalog's allowed descendant collections.
+      operationId: getCatalogSearch
+      parameters:
+        - name: collections
+          in: query
+          description: Array of collection IDs to search. The API computes the intersection with the catalog's allowed descendant collections.
+          schema:
+            type: array
+            items:
+              type: string
+        - name: bbox
+          in: query
+          description: Bounding box for spatial filtering (minx,miny,maxx,maxy)
+          schema:
+            type: array
+            items:
+              type: number
+        - name: datetime
+          in: query
+          description: Datetime range for temporal filtering (RFC 3339 format or open-ended ranges)
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of items to return
+          schema:
+            type: integer
+        - name: ids
+          in: query
+          description: Array of item IDs to search for
+          schema:
+            type: array
+            items:
+              type: string
+        - name: intersects
+          in: query
+          description: GeoJSON geometry for spatial filtering (alternative to bbox)
+          schema:
+            type: object
+      responses:
+        '200':
+          description: A GeoJSON FeatureCollection of matching items
+          content:
+            application/geo+json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollection'
+    post:
+      tags:
+        - "Discovery (Core)"
+      summary: Search items in a catalog's descendant tree
+      description: |
+        Performs a STAC item search strictly bounded to the hierarchy of {catalogId}.
+        Evaluates items from all Collections directly linked to {catalogId} and 
+        all Collections linked to any descendant Sub-Catalog nested beneath {catalogId}.
+        
+        Accepts the same request body as the core STAC `/search` endpoint. 
+        The `collections` parameter is intersected with the catalog's allowed descendant collections.
+      operationId: postCatalogSearch
+      requestBody:
+        description: Search query parameters (STAC search body)
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchBody'
+      responses:
+        '200':
+          description: A GeoJSON FeatureCollection of matching items
+          content:
+            application/geo+json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollection'
+
+  # ----------------------------------------------------------------------
+  # 7. SCOPED COLLECTIONS MANAGEMENT
   # ----------------------------------------------------------------------
   /catalogs/{catalogId}/collections:
     parameters:
@@ -258,7 +348,7 @@ paths:
           description: Existing Collection successfully linked
 
   # ----------------------------------------------------------------------
-  # 7. SCOPED SINGLE COLLECTION
+  # 8. SCOPED SINGLE COLLECTION
   # ----------------------------------------------------------------------
   /catalogs/{catalogId}/collections/{collectionId}:
     parameters:
@@ -324,7 +414,7 @@ paths:
           description: Collection unlinked successfully
 
   # ----------------------------------------------------------------------
-  # 8. SCOPED ITEMS (Search)
+  # 9. SCOPED ITEMS (Search)
   # ----------------------------------------------------------------------
   /catalogs/{catalogId}/collections/{collectionId}/items:
     parameters:
@@ -344,7 +434,7 @@ paths:
                 $ref: '#/components/schemas/FeatureCollection'
 
   # ----------------------------------------------------------------------
-  # 9. SCOPED SINGLE ITEM
+  # 10. SCOPED SINGLE ITEM
   # ----------------------------------------------------------------------
   /catalogs/{catalogId}/collections/{collectionId}/items/{itemId}:
     parameters:
@@ -369,7 +459,7 @@ paths:
                 $ref: '#/components/schemas/Item'
 
   # ----------------------------------------------------------------------
-  # 10. SUB-CATALOG QUERYABLES (Optional)
+  # 11. SUB-CATALOG QUERYABLES (Optional)
   # ----------------------------------------------------------------------
   /catalogs/{catalogId}/queryables:
     parameters:
@@ -388,7 +478,7 @@ paths:
                 $ref: '#/components/schemas/Queryables'
 
   # ----------------------------------------------------------------------
-  # 11. SCOPED COLLECTION QUERYABLES
+  # 12. SCOPED COLLECTION QUERYABLES
   # ----------------------------------------------------------------------
   /catalogs/{catalogId}/collections/{collectionId}/queryables:
     parameters:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -244,9 +244,11 @@ paths:
               type: string
         - name: bbox
           in: query
-          description: Bounding box for spatial filtering (minx,miny,maxx,maxy)
+          description: Bounding box for spatial filtering (minx,miny,maxx,maxy or minx,miny,minz,maxx,maxy,maxz)
           schema:
             type: array
+            minItems: 4
+            maxItems: 6
             items:
               type: number
         - name: datetime
@@ -269,8 +271,10 @@ paths:
         - name: intersects
           in: query
           description: GeoJSON geometry for spatial filtering (alternative to bbox)
-          schema:
-            type: object
+          content:
+            application/geo+json:
+              schema:
+                type: object
       responses:
         '200':
           description: A GeoJSON FeatureCollection of matching items
@@ -594,3 +598,6 @@ components:
     Queryables:
       type: object
       description: A JSON Schema object for queryables
+    SearchBody:
+      type: object
+      description: STAC Item Search request body (same shape as the core /search endpoint). Supports spatial (bbox, intersects), temporal (datetime), and collection filtering.


### PR DESCRIPTION
Added

- Scoped Search Endpoints: Introduced GET /catalogs/{catalogId}/search and POST /catalogs/{catalogId}/search to allow STAC item searches strictly bounded to a catalog's descendant tree. Included a new optional https://api.stacspec.org/v1.0.0-rc.2/multi-tenant-catalogs/search conformance class for APIs to explicitly advertise this capability.

Changed

- Release Candidate 2: Bumped the extension version and updated all associated conformance class URIs from v1.0.0-beta.4 to v1.0.0-rc.2 to reflect the progression toward a stable release.